### PR TITLE
judgeIfCatImage のテストコードの追加とリファクタリング

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         run: |
           docker-compose exec -T go make build
           docker-compose exec -T go make lint
-
+          docker-compose exec -T go make test-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,4 @@ jobs:
       - name: Execute test
         run: |
           docker-compose exec -T go make build
-          docker-compose exec -T go make lint
-          docker-compose exec -T go make test-ci
+          docker-compose exec -T go make ci

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean deploy test test-ci lint format generate-mock
+.PHONY: build clean deploy test lint format ci generate-mock
 
 build:
 	GOOS=linux GOARCH=amd64 go build -o bin/imagerecognition ./cmd/lambda/imagerecognition/main.go
@@ -18,10 +18,6 @@ test:
 	go clean -testcache
 	go test -p 1 -v $$(go list ./... | grep -v /node_modules/)
 
-test-ci:
-	go clean -testcache
-	go test -p 1 -v -coverprofile coverage.out -covermode atomic $$(go list ./... | grep -v /node_modules/)
-
 lint:
 	go vet ./...
 	golangci-lint run ./...
@@ -29,6 +25,11 @@ lint:
 format:
 	gofmt -l -s -w .
 	goimports -w -l ./
+
+ci: lint
+	go clean -testcache
+	go test -p 1 -v -coverprofile coverage.out -covermode atomic $$(go list ./... | grep -v /node_modules/)
+	go mod tidy && git diff -s --exit-code go.sum
 
 generate-mock:
 	mockgen -source=infrastructure/rekognition_client.go -destination mock/rekognition_client.go -package mock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # aws-rekognition-sandbox
 [![ci](https://github.com/keitakn/aws-rekognition-sandbox/actions/workflows/ci.yml/badge.svg)](https://github.com/keitakn/aws-rekognition-sandbox/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/keitakn/aws-rekognition-sandbox/badge.svg?branch=main)](https://coveralls.io/github/keitakn/aws-rekognition-sandbox?branch=main)
 [![cd](https://github.com/keitakn/aws-rekognition-sandbox/actions/workflows/cd.yml/badge.svg)](https://github.com/keitakn/aws-rekognition-sandbox/actions/workflows/cd.yml)
 
 Amazon Rekognitionで出来る事を調査する為の検証用プロジェクト

--- a/application/judge_if_cat_image_scenario.go
+++ b/application/judge_if_cat_image_scenario.go
@@ -1,0 +1,177 @@
+package application
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rekognition"
+	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/keitakn/aws-rekognition-sandbox/infrastructure"
+	"github.com/pkg/errors"
+)
+
+type JudgeIfCatImageScenario struct {
+	S3Client          infrastructure.S3Client
+	RekognitionClient infrastructure.RekognitionClient
+}
+
+type JudgeIfCatImageRequest struct {
+	TargetS3BucketName      string
+	TargetS3ObjectKey       string
+	TargetS3ObjectVersionId string
+}
+
+type IsCatImageResponse struct {
+	IsCatImage  bool     `json:"isCatImage"`
+	TypesOfCats []string `json:"typesOfCats"`
+}
+
+func (
+	s *JudgeIfCatImageScenario,
+) JudgeIfCatImage(
+	ctx context.Context,
+	req *JudgeIfCatImageRequest,
+) (*IsCatImageResponse, error) {
+	s3Object := &types.S3Object{
+		Bucket:  aws.String(req.TargetS3BucketName),
+		Name:    aws.String(req.TargetS3ObjectKey),
+		Version: aws.String(req.TargetS3ObjectVersionId),
+	}
+
+	ext := s.extractImageExtension(req.TargetS3ObjectKey)
+	if ext == "" {
+		// 拡張子が取れないという事はこれ以上処理は出来ないので関数を終了させる
+		return nil, errors.New("Not Allowed ImageExtension")
+	}
+
+	detectLabelsOutput, err := s.detectLabels(ctx, s3Object)
+	if err != nil {
+		return nil, errors.New("failed detectLabels")
+	}
+
+	// ねこ画像かどうかを判定する
+	isCatImageResponse := s.isCatImage(detectLabelsOutput.Labels)
+
+	return isCatImageResponse, nil
+}
+
+type CopyCatImageToDestinationBucketRequest struct {
+	TriggerBucketName     string
+	DestinationBucketName string
+	TargetS3ObjectKey     string
+}
+
+func (
+	s *JudgeIfCatImageScenario,
+) CopyCatImageToDestinationBucket(
+	ctx context.Context,
+	req *CopyCatImageToDestinationBucketRequest,
+) error {
+	copySource := fmt.Sprintf(
+		"%s/%s",
+		req.TriggerBucketName,
+		req.TargetS3ObjectKey,
+	)
+
+	uploadKey := "cat-images/" + strings.ReplaceAll(req.TargetS3ObjectKey, "tmp/", "")
+
+	err := s.copyS3Object(ctx, copySource, req.DestinationBucketName, uploadKey)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *JudgeIfCatImageScenario) detectLabels(
+	ctx context.Context,
+	s3Object *types.S3Object,
+) (*rekognition.DetectLabelsOutput, error) {
+	// 画像解析
+	rekognitionImage := &types.Image{
+		S3Object: s3Object,
+	}
+
+	// 何個までラベルを取得するかの設定、ラベルは信頼度が高い順に並んでいる
+	const maxLabels = int32(10)
+	// 信頼度の閾値、Confidenceがここで設定した値未満の場合、そのラベルはレスポンスに含まれない
+	const minConfidence = float32(85)
+
+	input := &rekognition.DetectLabelsInput{
+		Image:         rekognitionImage,
+		MaxLabels:     aws.Int32(maxLabels),
+		MinConfidence: aws.Float32(minConfidence),
+	}
+
+	output, err := s.RekognitionClient.DetectLabels(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func (s *JudgeIfCatImageScenario) copyS3Object(
+	ctx context.Context,
+	copySource string,
+	toBucket string,
+	uploadKey string,
+) error {
+	input := &s3.CopyObjectInput{
+		Bucket:     aws.String(toBucket),
+		CopySource: aws.String(copySource),
+		Key:        aws.String(uploadKey),
+	}
+
+	_, err := s.S3Client.CopyObject(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *JudgeIfCatImageScenario) isCatImage(labels []types.Label) *IsCatImageResponse {
+	isCatImageResponse := &IsCatImageResponse{
+		IsCatImage: false,
+	}
+
+	for _, label := range labels {
+		// ラベルにCatが含まれていて、かつConfidenceが閾値より大きい場合はねこの画像と見なす
+		const confidenceThreshold = 90
+		if *label.Name == "Cat" && *label.Confidence > confidenceThreshold {
+			isCatImageResponse.IsCatImage = true
+		}
+
+		// ねこの種類を判別する為の処理
+		// label.Parents に "Cat" が含まれていれば、そのラベルはねこの種類という事にしている
+		// .e.g. test/images/abyssinian-cat.jpg の場合は {"isCatImage": true, "typesOfCats": ["Abyssinian"]}
+		// .e.g. test/images/manx-cat.jpg の場合は {"isCatImage": true, "typesOfCats": ["Manx"]}
+		for _, parent := range label.Parents {
+			if *parent.Name == "Cat" {
+				isCatImageResponse.TypesOfCats = append(isCatImageResponse.TypesOfCats, *label.Name)
+			}
+		}
+	}
+
+	return isCatImageResponse
+}
+
+func (s *JudgeIfCatImageScenario) extractImageExtension(fileName string) string {
+	// 許可されている画像拡張子
+	allowedImageExtList := [...]string{".jpg", ".jpeg", ".png", ".webp"}
+
+	ext := filepath.Ext(fileName)
+
+	for _, v := range allowedImageExtList {
+		if ext == v {
+			return v
+		}
+	}
+
+	return ""
+}

--- a/cmd/lambda/judgeifcatimage/main.go
+++ b/cmd/lambda/judgeifcatimage/main.go
@@ -2,23 +2,18 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
-	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/keitakn/aws-rekognition-sandbox/application"
 )
 
-var s3Client *s3.Client
-var rekognitionClient *rekognition.Client
+var scenario *application.JudgeIfCatImageScenario
 
 //nolint:gochecknoinits
 func init() {
@@ -31,154 +26,46 @@ func init() {
 		log.Fatalln(err)
 	}
 
-	s3Client = s3.NewFromConfig(cfg)
+	s3Client := s3.NewFromConfig(cfg)
 
-	rekognitionClient = rekognition.NewFromConfig(cfg)
-}
+	rekognitionClient := rekognition.NewFromConfig(cfg)
 
-func detectLabels(
-	ctx context.Context,
-	rekognitionClient *rekognition.Client,
-	s3Object *types.S3Object,
-) (*rekognition.DetectLabelsOutput, error) {
-	// 画像解析
-	rekognitionImage := &types.Image{
-		S3Object: s3Object,
+	scenario = &application.JudgeIfCatImageScenario{
+		S3Client:          s3Client,
+		RekognitionClient: rekognitionClient,
 	}
-
-	// 何個までラベルを取得するかの設定、ラベルは信頼度が高い順に並んでいる
-	const maxLabels = int32(10)
-	// 信頼度の閾値、Confidenceがここで設定した値未満の場合、そのラベルはレスポンスに含まれない
-	const minConfidence = float32(85)
-
-	input := &rekognition.DetectLabelsInput{
-		Image:         rekognitionImage,
-		MaxLabels:     aws.Int32(maxLabels),
-		MinConfidence: aws.Float32(minConfidence),
-	}
-
-	output, err := rekognitionClient.DetectLabels(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-
-	return output, nil
-}
-
-func copyS3Object(
-	ctx context.Context,
-	s3Client *s3.Client,
-	copySource string,
-	toBucket string,
-	uploadKey string,
-) error {
-	input := &s3.CopyObjectInput{
-		Bucket:     aws.String(toBucket),
-		CopySource: aws.String(copySource),
-		Key:        aws.String(uploadKey),
-	}
-
-	_, err := s3Client.CopyObject(ctx, input)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-type IsCatImageResult struct {
-	IsCatImage  bool     `json:"isCatImage"`
-	TypesOfCats []string `json:"typesOfCats"`
-}
-
-func isCatImage(labels []types.Label) *IsCatImageResult {
-	isCatImageResult := &IsCatImageResult{
-		IsCatImage: false,
-	}
-
-	for _, label := range labels {
-		// ラベルにCatが含まれていて、かつConfidenceが閾値より大きい場合はねこの画像と見なす
-		const confidenceThreshold = 90
-		if *label.Name == "Cat" && *label.Confidence > confidenceThreshold {
-			isCatImageResult.IsCatImage = true
-		}
-
-		// ねこの種類を判別する為の処理
-		// label.Parents に "Cat" が含まれていれば、そのラベルはねこの種類という事にしている
-		// .e.g. test/images/abyssinian-cat.jpg の場合は {"isCatImage": true, "typesOfCats": ["Abyssinian"]}
-		// .e.g. test/images/manx-cat.jpg の場合は {"isCatImage": true, "typesOfCats": ["Manx"]}
-		for _, parent := range label.Parents {
-			if *parent.Name == "Cat" {
-				isCatImageResult.TypesOfCats = append(isCatImageResult.TypesOfCats, *label.Name)
-			}
-		}
-	}
-
-	return isCatImageResult
-}
-
-func extractImageExtension(fileName string) string {
-	// 許可されている画像拡張子
-	allowedImageExtList := [...]string{".jpg", ".jpeg", ".png", ".webp"}
-
-	ext := filepath.Ext(fileName)
-
-	for _, v := range allowedImageExtList {
-		if ext == v {
-			return v
-		}
-	}
-
-	return ""
 }
 
 func Handler(ctx context.Context, event events.S3Event) error {
 	for _, record := range event.Records {
 		// recordの中にイベント発生させたS3のBucket名やKeyが入っている
-		bucket := record.S3.Bucket.Name
-		key := record.S3.Object.Key
-
-		s3Object := &types.S3Object{
-			Bucket:  aws.String(bucket),
-			Name:    aws.String(key),
-			Version: aws.String(record.S3.Object.VersionID),
+		judgeIfCatImageRequest := &application.JudgeIfCatImageRequest{
+			TargetS3BucketName:      record.S3.Bucket.Name,
+			TargetS3ObjectKey:       record.S3.Object.Key,
+			TargetS3ObjectVersionId: record.S3.Object.VersionID,
 		}
 
-		ext := extractImageExtension(key)
-		if ext == "" {
-			// 拡張子が取れないという事はこれ以上処理は出来ないので関数を終了させる
-			return nil
-		}
-
-		detectLabelsOutput, err := detectLabels(ctx, rekognitionClient, s3Object)
+		// ねこ画像かどうかを判定する
+		isCatImageResponse, err := scenario.JudgeIfCatImage(ctx, judgeIfCatImageRequest)
 		if err != nil {
 			return err
 		}
 
-		// ねこ画像かどうかを判定する
-		isCatImageResult := isCatImage(detectLabelsOutput.Labels)
-
 		// ねこ画像ではない場合、ここで処理を中断する
-		if !isCatImageResult.IsCatImage {
+		if !isCatImageResponse.IsCatImage {
 			continue
 		}
 
-		uploadKey := "cat-images/" + strings.ReplaceAll(key, "tmp/", "")
+		copyCatImageRequest := &application.CopyCatImageToDestinationBucketRequest{
+			// TriggerBucketName, DestinationBucketNameに同じ値が設定されているが、同じバケットの異なるディレクトリを使っているから
+			// 実運用の際は別のバケットを指定したほうが良い
+			TriggerBucketName:     os.Getenv("TRIGGER_BUCKET_NAME"),
+			DestinationBucketName: os.Getenv("TRIGGER_BUCKET_NAME"),
+			TargetS3ObjectKey:     judgeIfCatImageRequest.TargetS3ObjectKey,
+		}
 
-		copySource := fmt.Sprintf(
-			"%s/%s",
-			os.Getenv("TRIGGER_BUCKET_NAME"),
-			key,
-		)
-
-		err = copyS3Object(
-			ctx,
-			s3Client,
-			copySource,
-			os.Getenv("TRIGGER_BUCKET_NAME"),
-			uploadKey,
-		)
-
+		// ここまで来るという事はねこ画像なので指定された場所にアップロードする
+		err = scenario.CopyCatImageToDestinationBucket(ctx, copyCatImageRequest)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.4.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.2.0
+	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/infrastructure/s3_client.go
+++ b/infrastructure/s3_client.go
@@ -1,0 +1,15 @@
+package infrastructure
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type S3Client interface {
+	CopyObject(
+		ctx context.Context,
+		params *s3.CopyObjectInput,
+		optFns ...func(*s3.Options),
+	) (*s3.CopyObjectOutput, error)
+}

--- a/test/scenario/judgeifcatimagetest/judge_if_cat_image_scenario_test.go
+++ b/test/scenario/judgeifcatimagetest/judge_if_cat_image_scenario_test.go
@@ -22,15 +22,16 @@ func TestMain(m *testing.M) {
 
 //nolint:funlen
 func TestHandler(t *testing.T) {
-	t.Run("Successful judged to be a cat image", func(t *testing.T) {
+	const expectedTriggerBucketName = "trigger-bucket"
+	const expectedTargetS3ObjectVersionId = "AAAAA.1234567890123456789abcdefg"
+	const catLabelName = "Cat"
+
+	t.Run("judged to be a cat image", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
-
-		expectedTriggerBucketName := "trigger-bucket"
 		expectedTargetS3ObjectKey := "tmp/sample-cat-image.jpg"
-		expectedTargetS3ObjectVersionId := "AAAAA.1234567890123456789abcdefg"
 
 		s3Object := &types.S3Object{
 			Bucket:  aws.String(expectedTriggerBucketName),
@@ -54,9 +55,9 @@ func TestHandler(t *testing.T) {
 		}
 
 		confidenceExpected := float32(90.1)
-		expectedFirstLabelName := "Cat"
+		expectedFirstLabelName := catLabelName
 		expectedSecondLabelName := "ChinchillaSilver"
-		expectedFirstParentsName := "Cat"
+		expectedFirstParentsName := catLabelName
 
 		parents := []types.Parent{
 			{Name: aws.String(expectedFirstParentsName)},
@@ -93,6 +94,140 @@ func TestHandler(t *testing.T) {
 		expected := &application.IsCatImageResponse{
 			IsCatImage:  true,
 			TypesOfCats: []string{expectedSecondLabelName},
+		}
+
+		if reflect.DeepEqual(res, expected) == false {
+			t.Error("\nActually: ", res, "\nExpected: ", expected)
+		}
+	})
+
+	t.Run("judged that it is not a cat image, because the confidence value is low", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
+		expectedTargetS3ObjectKey := "tmp/sample-cat-image.jpg"
+
+		s3Object := &types.S3Object{
+			Bucket:  aws.String(expectedTriggerBucketName),
+			Name:    aws.String(expectedTargetS3ObjectKey),
+			Version: aws.String(expectedTargetS3ObjectVersionId),
+		}
+
+		rekognitionImage := &types.Image{
+			S3Object: s3Object,
+		}
+
+		// 何個までラベルを取得するかの設定、ラベルは信頼度が高い順に並んでいる
+		const maxLabels = int32(10)
+		// 信頼度の閾値、Confidenceがここで設定した値未満の場合、そのラベルはレスポンスに含まれない
+		const minConfidence = float32(85)
+
+		detectLabelsInput := &rekognition.DetectLabelsInput{
+			Image:         rekognitionImage,
+			MaxLabels:     aws.Int32(maxLabels),
+			MinConfidence: aws.Float32(minConfidence),
+		}
+
+		confidenceExpected := float32(90.0)
+		expectedFirstLabelName := catLabelName
+
+		labels := []types.Label{
+			{Confidence: aws.Float32(confidenceExpected), Name: aws.String(expectedFirstLabelName)},
+		}
+
+		detectLabelsOutput := &rekognition.DetectLabelsOutput{
+			Labels: labels,
+		}
+
+		ctx := context.Background()
+
+		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
+
+		scenario := application.JudgeIfCatImageScenario{
+			RekognitionClient: mockRekognitionClient,
+		}
+
+		req := &application.JudgeIfCatImageRequest{
+			TargetS3BucketName:      expectedTriggerBucketName,
+			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
+			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
+		}
+
+		res, err := scenario.JudgeIfCatImage(ctx, req)
+		if err != nil {
+			t.Fatal("Failed JudgeIfCatImage", err)
+		}
+
+		expected := &application.IsCatImageResponse{
+			IsCatImage: false,
+		}
+
+		if reflect.DeepEqual(res, expected) == false {
+			t.Error("\nActually: ", res, "\nExpected: ", expected)
+		}
+	})
+
+	t.Run("judged that it is not a cat image, because there is no cat in the image", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
+		expectedTargetS3ObjectKey := "tmp/sample-dog-image.jpg"
+
+		s3Object := &types.S3Object{
+			Bucket:  aws.String(expectedTriggerBucketName),
+			Name:    aws.String(expectedTargetS3ObjectKey),
+			Version: aws.String(expectedTargetS3ObjectVersionId),
+		}
+
+		rekognitionImage := &types.Image{
+			S3Object: s3Object,
+		}
+
+		// 何個までラベルを取得するかの設定、ラベルは信頼度が高い順に並んでいる
+		const maxLabels = int32(10)
+		// 信頼度の閾値、Confidenceがここで設定した値未満の場合、そのラベルはレスポンスに含まれない
+		const minConfidence = float32(85)
+
+		detectLabelsInput := &rekognition.DetectLabelsInput{
+			Image:         rekognitionImage,
+			MaxLabels:     aws.Int32(maxLabels),
+			MinConfidence: aws.Float32(minConfidence),
+		}
+
+		confidenceExpected := float32(99.9)
+		expectedFirstLabelName := "Dog"
+
+		labels := []types.Label{
+			{Confidence: aws.Float32(confidenceExpected), Name: aws.String(expectedFirstLabelName)},
+		}
+
+		detectLabelsOutput := &rekognition.DetectLabelsOutput{
+			Labels: labels,
+		}
+
+		ctx := context.Background()
+
+		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
+
+		scenario := application.JudgeIfCatImageScenario{
+			RekognitionClient: mockRekognitionClient,
+		}
+
+		req := &application.JudgeIfCatImageRequest{
+			TargetS3BucketName:      expectedTriggerBucketName,
+			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
+			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
+		}
+
+		res, err := scenario.JudgeIfCatImage(ctx, req)
+		if err != nil {
+			t.Fatal("Failed JudgeIfCatImage", err)
+		}
+
+		expected := &application.IsCatImageResponse{
+			IsCatImage: false,
 		}
 
 		if reflect.DeepEqual(res, expected) == false {

--- a/test/scenario/judgeifcatimagetest/judge_if_cat_image_scenario_test.go
+++ b/test/scenario/judgeifcatimagetest/judge_if_cat_image_scenario_test.go
@@ -234,4 +234,30 @@ func TestHandler(t *testing.T) {
 			t.Error("\nActually: ", res, "\nExpected: ", expected)
 		}
 	})
+
+	t.Run("failure it is not an allowed image extension", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
+		expectedTargetS3ObjectKey := "tmp/sample-cat-image.gif"
+
+		scenario := application.JudgeIfCatImageScenario{
+			RekognitionClient: mockRekognitionClient,
+		}
+
+		req := &application.JudgeIfCatImageRequest{
+			TargetS3BucketName:      expectedTriggerBucketName,
+			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
+			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
+		}
+
+		ctx := context.Background()
+
+		expected := "Not Allowed ImageExtension"
+		res, err := scenario.JudgeIfCatImage(ctx, req)
+		if err == nil {
+			t.Error("\nActually: ", res, "\nExpected: ", expected)
+		}
+	})
 }

--- a/test/scenario/judgeifcatimagetest/judge_if_cat_image_scenario_test.go
+++ b/test/scenario/judgeifcatimagetest/judge_if_cat_image_scenario_test.go
@@ -1,0 +1,102 @@
+package judgeifcatimagetest
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rekognition"
+	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
+	"github.com/golang/mock/gomock"
+	"github.com/keitakn/aws-rekognition-sandbox/application"
+	"github.com/keitakn/aws-rekognition-sandbox/mock"
+)
+
+func TestMain(m *testing.M) {
+	status := m.Run()
+
+	os.Exit(status)
+}
+
+//nolint:funlen
+func TestHandler(t *testing.T) {
+	t.Run("Successful judged to be a cat image", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
+
+		expectedTriggerBucketName := "trigger-bucket"
+		expectedTargetS3ObjectKey := "tmp/sample-cat-image.jpg"
+		expectedTargetS3ObjectVersionId := "AAAAA.1234567890123456789abcdefg"
+
+		s3Object := &types.S3Object{
+			Bucket:  aws.String(expectedTriggerBucketName),
+			Name:    aws.String(expectedTargetS3ObjectKey),
+			Version: aws.String(expectedTargetS3ObjectVersionId),
+		}
+
+		rekognitionImage := &types.Image{
+			S3Object: s3Object,
+		}
+
+		// 何個までラベルを取得するかの設定、ラベルは信頼度が高い順に並んでいる
+		const maxLabels = int32(10)
+		// 信頼度の閾値、Confidenceがここで設定した値未満の場合、そのラベルはレスポンスに含まれない
+		const minConfidence = float32(85)
+
+		detectLabelsInput := &rekognition.DetectLabelsInput{
+			Image:         rekognitionImage,
+			MaxLabels:     aws.Int32(maxLabels),
+			MinConfidence: aws.Float32(minConfidence),
+		}
+
+		confidenceExpected := float32(90.1)
+		expectedFirstLabelName := "Cat"
+		expectedSecondLabelName := "ChinchillaSilver"
+		expectedFirstParentsName := "Cat"
+
+		parents := []types.Parent{
+			{Name: aws.String(expectedFirstParentsName)},
+		}
+
+		labels := []types.Label{
+			{Confidence: aws.Float32(confidenceExpected), Name: aws.String(expectedFirstLabelName)},
+			{Confidence: aws.Float32(confidenceExpected), Name: aws.String(expectedSecondLabelName), Parents: parents},
+		}
+
+		detectLabelsOutput := &rekognition.DetectLabelsOutput{
+			Labels: labels,
+		}
+
+		ctx := context.Background()
+
+		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
+
+		scenario := application.JudgeIfCatImageScenario{
+			RekognitionClient: mockRekognitionClient,
+		}
+
+		req := &application.JudgeIfCatImageRequest{
+			TargetS3BucketName:      expectedTriggerBucketName,
+			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
+			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
+		}
+
+		res, err := scenario.JudgeIfCatImage(ctx, req)
+		if err != nil {
+			t.Fatal("Failed JudgeIfCatImage", err)
+		}
+
+		expected := &application.IsCatImageResponse{
+			IsCatImage:  true,
+			TypesOfCats: []string{expectedSecondLabelName},
+		}
+
+		if reflect.DeepEqual(res, expected) == false {
+			t.Error("\nActually: ", res, "\nExpected: ", expected)
+		}
+	})
+}


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/aws-rekognition-sandbox/issues/5

# やった事
テストコードを書きやすくする為に `main.go` からメインロジックを分離してテストケースを追加。

`detectLabels` にImageを渡す際に一度ダウンロードしてBase64化して渡していたが、手間がかかり、Mock化するのも大変なのでS3バケットの情報を渡すように変更。

またCI上でLinterの実行しか行われないようになっていたので、テストの実行を含め必要なチェックが全て行われるように修正しました。