### PR TITLE
カバレッジを出力するように変更、他軽微なリファクタリング

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           docker-compose exec -T go make ci
       - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.5
+        uses: jandelgado/gcov2lcov-action@v1.0.8
         with:
           infile: coverage.out
           outfile: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,13 @@ jobs:
         run: |
           docker-compose exec -T go make build
           docker-compose exec -T go make ci
+      - name: Convert coverage to lcov
+        uses: jandelgado/gcov2lcov-action@v1.0.0
+        with:
+          infile: coverage.out
+          outfile: coverage.lcov
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           docker-compose exec -T go make ci
       - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.8
+        uses: jandelgado/gcov2lcov-action@v1.0.6
         with:
           infile: coverage.out
           outfile: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           docker-compose up --build -d
       - name: Execute test
         run: |
-          docker-compose exec -T go make build
           docker-compose exec -T go make ci
       - name: Convert coverage to lcov
         uses: jandelgado/gcov2lcov-action@v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           infile: coverage.out
           outfile: coverage.lcov
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v1.0.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           infile: coverage.out
           outfile: coverage.lcov
       - name: Coveralls
-        uses: coverallsapp/github-action@v1.0.4
+        uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           docker-compose exec -T go make ci
       - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.0
+        uses: jandelgado/gcov2lcov-action@v1.0.5
         with:
           infile: coverage.out
           outfile: coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,3 @@ jobs:
       - name: Execute test
         run: |
           docker-compose exec -T go make ci
-      - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.6
-        with:
-          infile: coverage.out
-          outfile: coverage.lcov
-      - name: Coveralls
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage.lcov

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format:
 ci: clean build lint
 	go mod tidy && git diff -s --exit-code go.sum
 	go clean -testcache
-	go test -p 1 -v -coverprofile coverage.out -covermode atomic $$(go list ./... | grep -v /node_modules/)
+	go test -p 1 -v -coverprofile coverage.out -covermode count $$(go list ./... | grep -v /node_modules/)
 
 generate-mock:
 	mockgen -source=infrastructure/rekognition_client.go -destination mock/rekognition_client.go -package mock

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ format:
 	gofmt -l -s -w .
 	goimports -w -l ./
 
-ci: lint
+ci: clean build lint
 	go clean -testcache
 	go test -p 1 -v -coverprofile coverage.out -covermode atomic $$(go list ./... | grep -v /node_modules/)
 	go mod tidy && git diff -s --exit-code go.sum

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format:
 ci: clean build lint
 	go mod tidy && git diff -s --exit-code go.sum
 	go clean -testcache
-	go test -p 1 -v -coverprofile coverage.out -covermode count $$(go list ./... | grep -v /node_modules/)
+	go test -p 1 -v -coverprofile coverage.out -covermode atomic $$(go list ./... | grep -v /node_modules/)
 
 generate-mock:
 	mockgen -source=infrastructure/rekognition_client.go -destination mock/rekognition_client.go -package mock

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ format:
 	goimports -w -l ./
 
 ci: clean build lint
+	go mod tidy && git diff -s --exit-code go.sum
 	go clean -testcache
 	go test -p 1 -v -coverprofile coverage.out -covermode atomic $$(go list ./... | grep -v /node_modules/)
-	go mod tidy && git diff -s --exit-code go.sum
 
 generate-mock:
 	mockgen -source=infrastructure/rekognition_client.go -destination mock/rekognition_client.go -package mock

--- a/application/scenario/detectfaces/detect_faces_scenario.go
+++ b/application/scenario/detectfaces/detect_faces_scenario.go
@@ -1,4 +1,4 @@
-package application
+package detectfaces
 
 import (
 	"context"

--- a/application/scenario/detectfaces/detect_faces_scenario_test.go
+++ b/application/scenario/detectfaces/detect_faces_scenario_test.go
@@ -1,4 +1,4 @@
-package detectfacestest
+package detectfaces
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
 	"github.com/golang/mock/gomock"
-	"github.com/keitakn/aws-rekognition-sandbox/application"
 	"github.com/keitakn/aws-rekognition-sandbox/mock"
 	"github.com/keitakn/aws-rekognition-sandbox/test"
 )
@@ -29,7 +28,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -54,18 +53,18 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(expectedDetectFacesOutput, nil)
 
-		req := &application.DetectFacesRequestBody{
+		req := &DetectFacesRequestBody{
 			Image: base64Img,
 		}
 
-		scenario := &application.DetectFacesScenario{
+		scenario := &DetectFacesScenario{
 			RekognitionClient: mockClient,
 		}
 
 		res := scenario.DetectFaces(ctx, *req)
 
-		expected := &application.DetectFacesResponse{
-			OkBody: &application.DetectFacesResponseOkBody{
+		expected := &DetectFacesResponse{
+			OkBody: &DetectFacesResponseOkBody{
 				DetectFacesOutput: expectedDetectFacesOutput,
 			},
 			IsError: false,
@@ -87,7 +86,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../images/munchkin-cat.png")
+		base64Img, err := test.EncodeImageToBase64("../../../test/images/munchkin-cat.png")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -111,18 +110,18 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(expectedDetectFacesOutput, nil)
 
-		req := &application.DetectFacesRequestBody{
+		req := &DetectFacesRequestBody{
 			Image: base64Img,
 		}
 
-		scenario := &application.DetectFacesScenario{
+		scenario := &DetectFacesScenario{
 			RekognitionClient: mockClient,
 		}
 
 		res := scenario.DetectFaces(ctx, *req)
 
-		expected := &application.DetectFacesResponse{
-			OkBody: &application.DetectFacesResponseOkBody{
+		expected := &DetectFacesResponse{
+			OkBody: &DetectFacesResponseOkBody{
 				DetectFacesOutput: expectedDetectFacesOutput,
 			},
 			IsError: false,
@@ -144,7 +143,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../images/munchkin-cat.png")
+		base64Img, err := test.EncodeImageToBase64("../../../test/images/munchkin-cat.png")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -163,18 +162,18 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(nil, expectedDetectError)
 
-		req := &application.DetectFacesRequestBody{
+		req := &DetectFacesRequestBody{
 			Image: base64Img,
 		}
 
-		scenario := &application.DetectFacesScenario{
+		scenario := &DetectFacesScenario{
 			RekognitionClient: mockClient,
 		}
 
 		res := scenario.DetectFaces(ctx, *req)
 
-		expected := &application.DetectFacesResponse{
-			ErrorBody: &application.DetectFacesResponseErrorBody{Message: "Failed detectFaces"},
+		expected := &DetectFacesResponse{
+			ErrorBody: &DetectFacesResponseErrorBody{Message: "Failed detectFaces"},
 			IsError:   true,
 		}
 

--- a/application/scenario/imagerecognition/image_recognition_scenario.go
+++ b/application/scenario/imagerecognition/image_recognition_scenario.go
@@ -1,4 +1,4 @@
-package application
+package imagerecognition
 
 import (
 	"bytes"

--- a/application/scenario/imagerecognition/image_recognition_scenario_test.go
+++ b/application/scenario/imagerecognition/image_recognition_scenario_test.go
@@ -1,4 +1,4 @@
-package imagerecognitiontest
+package imagerecognition
 
 import (
 	"bytes"
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"os"
 	"testing"
-
-	"github.com/keitakn/aws-rekognition-sandbox/application"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -35,7 +33,7 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -105,13 +103,13 @@ func TestHandler(t *testing.T) {
 		mockUniqueIdGenerator := mock.NewMockUniqueIdGenerator(ctrl)
 		mockUniqueIdGenerator.EXPECT().Generate().Return(mockUuid, nil)
 
-		scenario := application.ImageRecognitionScenario{
+		scenario := ImageRecognitionScenario{
 			RekognitionClient: mockRekognitionClient,
 			S3Uploader:        mockS3Uploader,
 			UniqueIdGenerator: mockUniqueIdGenerator,
 		}
 
-		req := application.ImageRecognitionRequestBody{
+		req := ImageRecognitionRequestBody{
 			Image:          base64Img,
 			ImageExtension: ".jpg",
 		}
@@ -142,7 +140,7 @@ func TestHandler(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		base64Img, err := test.EncodeImageToBase64("../../images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -154,13 +152,13 @@ func TestHandler(t *testing.T) {
 		mockUniqueIdGenerator := mock.NewMockUniqueIdGenerator(ctrl)
 		mockUniqueIdGenerator.EXPECT().Generate().Return("", errors.New("failed Generate UUID"))
 
-		scenario := application.ImageRecognitionScenario{
+		scenario := ImageRecognitionScenario{
 			RekognitionClient: mockRekognitionClient,
 			S3Uploader:        mockS3Uploader,
 			UniqueIdGenerator: mockUniqueIdGenerator,
 		}
 
-		req := application.ImageRecognitionRequestBody{
+		req := ImageRecognitionRequestBody{
 			Image:          base64Img,
 			ImageExtension: ".jpg",
 		}
@@ -184,7 +182,7 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -214,13 +212,13 @@ func TestHandler(t *testing.T) {
 		mockUniqueIdGenerator := mock.NewMockUniqueIdGenerator(ctrl)
 		mockUniqueIdGenerator.EXPECT().Generate().Return(mockUuid, nil)
 
-		scenario := application.ImageRecognitionScenario{
+		scenario := ImageRecognitionScenario{
 			RekognitionClient: mockRekognitionClient,
 			S3Uploader:        mockS3Uploader,
 			UniqueIdGenerator: mockUniqueIdGenerator,
 		}
 
-		req := application.ImageRecognitionRequestBody{
+		req := ImageRecognitionRequestBody{
 			Image:          base64Img,
 			ImageExtension: ".jpg",
 		}
@@ -243,7 +241,7 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -295,13 +293,13 @@ func TestHandler(t *testing.T) {
 		mockUniqueIdGenerator := mock.NewMockUniqueIdGenerator(ctrl)
 		mockUniqueIdGenerator.EXPECT().Generate().Return(mockUuid, nil)
 
-		scenario := application.ImageRecognitionScenario{
+		scenario := ImageRecognitionScenario{
 			RekognitionClient: mockRekognitionClient,
 			S3Uploader:        mockS3Uploader,
 			UniqueIdGenerator: mockUniqueIdGenerator,
 		}
 
-		req := application.ImageRecognitionRequestBody{
+		req := ImageRecognitionRequestBody{
 			Image:          base64Img,
 			ImageExtension: ".jpg",
 		}

--- a/application/scenario/judgeifcatimage/judge_if_cat_image_scenario.go
+++ b/application/scenario/judgeifcatimage/judge_if_cat_image_scenario.go
@@ -1,4 +1,4 @@
-package application
+package judgeifcatimage
 
 import (
 	"context"

--- a/application/scenario/judgeifcatimage/judge_if_cat_image_scenario_test.go
+++ b/application/scenario/judgeifcatimage/judge_if_cat_image_scenario_test.go
@@ -1,4 +1,4 @@
-package judgeifcatimagetest
+package judgeifcatimage
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
 	"github.com/golang/mock/gomock"
-	"github.com/keitakn/aws-rekognition-sandbox/application"
 	"github.com/keitakn/aws-rekognition-sandbox/mock"
 	"github.com/pkg/errors"
 )
@@ -77,11 +76,11 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
 
-		scenario := application.JudgeIfCatImageScenario{
+		scenario := JudgeIfCatImageScenario{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &application.JudgeIfCatImageRequest{
+		req := &JudgeIfCatImageRequest{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
@@ -92,7 +91,7 @@ func TestHandler(t *testing.T) {
 			t.Fatal("Failed JudgeIfCatImage", err)
 		}
 
-		expected := &application.IsCatImageResponse{
+		expected := &IsCatImageResponse{
 			IsCatImage:  true,
 			TypesOfCats: []string{expectedSecondLabelName},
 		}
@@ -145,11 +144,11 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
 
-		scenario := application.JudgeIfCatImageScenario{
+		scenario := JudgeIfCatImageScenario{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &application.JudgeIfCatImageRequest{
+		req := &JudgeIfCatImageRequest{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
@@ -160,7 +159,7 @@ func TestHandler(t *testing.T) {
 			t.Fatal("Failed JudgeIfCatImage", err)
 		}
 
-		expected := &application.IsCatImageResponse{
+		expected := &IsCatImageResponse{
 			IsCatImage: false,
 		}
 
@@ -212,11 +211,11 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
 
-		scenario := application.JudgeIfCatImageScenario{
+		scenario := JudgeIfCatImageScenario{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &application.JudgeIfCatImageRequest{
+		req := &JudgeIfCatImageRequest{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
@@ -227,7 +226,7 @@ func TestHandler(t *testing.T) {
 			t.Fatal("Failed JudgeIfCatImage", err)
 		}
 
-		expected := &application.IsCatImageResponse{
+		expected := &IsCatImageResponse{
 			IsCatImage: false,
 		}
 
@@ -243,11 +242,11 @@ func TestHandler(t *testing.T) {
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
 		expectedTargetS3ObjectKey := "tmp/sample-cat-image.gif"
 
-		scenario := application.JudgeIfCatImageScenario{
+		scenario := JudgeIfCatImageScenario{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &application.JudgeIfCatImageRequest{
+		req := &JudgeIfCatImageRequest{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
@@ -300,11 +299,11 @@ func TestHandler(t *testing.T) {
 			errors.New("failed rekognitionClient detectLabels"),
 		)
 
-		scenario := application.JudgeIfCatImageScenario{
+		scenario := JudgeIfCatImageScenario{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &application.JudgeIfCatImageRequest{
+		req := &JudgeIfCatImageRequest{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,

--- a/cmd/lambda/detectfaces/main.go
+++ b/cmd/lambda/detectfaces/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/keitakn/aws-rekognition-sandbox/application"
 )
 
-var rekognitionClient *rekognition.Client
+var scenario *application.DetectFacesScenario
 
 //nolint:gochecknoinits
 func init() {
@@ -26,7 +26,9 @@ func init() {
 		log.Fatalln(err)
 	}
 
-	rekognitionClient = rekognition.NewFromConfig(cfg)
+	rekognitionClient := rekognition.NewFromConfig(cfg)
+
+	scenario = &application.DetectFacesScenario{RekognitionClient: rekognitionClient}
 }
 
 func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGatewayV2HTTPResponse {
@@ -67,8 +69,6 @@ func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 
 		return res, err
 	}
-
-	scenario := &application.DetectFacesScenario{RekognitionClient: rekognitionClient}
 
 	scenarioRes := scenario.DetectFaces(ctx, reqBody)
 	if scenarioRes.IsError {

--- a/cmd/lambda/detectfaces/main.go
+++ b/cmd/lambda/detectfaces/main.go
@@ -10,10 +10,10 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
-	"github.com/keitakn/aws-rekognition-sandbox/application"
+	"github.com/keitakn/aws-rekognition-sandbox/application/scenario/detectfaces"
 )
 
-var scenario *application.DetectFacesScenario
+var scenario *detectfaces.DetectFacesScenario
 
 //nolint:gochecknoinits
 func init() {
@@ -28,7 +28,7 @@ func init() {
 
 	rekognitionClient := rekognition.NewFromConfig(cfg)
 
-	scenario = &application.DetectFacesScenario{RekognitionClient: rekognitionClient}
+	scenario = &detectfaces.DetectFacesScenario{RekognitionClient: rekognitionClient}
 }
 
 func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGatewayV2HTTPResponse {
@@ -45,7 +45,7 @@ func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGa
 }
 
 func createErrorResponse(statusCode int, message string) events.APIGatewayV2HTTPResponse {
-	resBody := &application.DetectFacesResponseErrorBody{Message: message}
+	resBody := &detectfaces.DetectFacesResponseErrorBody{Message: message}
 	resBodyJson, _ := json.Marshal(resBody)
 
 	res := events.APIGatewayV2HTTPResponse{
@@ -61,7 +61,7 @@ func createErrorResponse(statusCode int, message string) events.APIGatewayV2HTTP
 }
 
 func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
-	var reqBody application.DetectFacesRequestBody
+	var reqBody detectfaces.DetectFacesRequestBody
 	if err := json.Unmarshal([]byte(req.Body), &reqBody); err != nil {
 		statusCode := 400
 

--- a/cmd/lambda/imagerecognition/main.go
+++ b/cmd/lambda/imagerecognition/main.go
@@ -12,11 +12,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/keitakn/aws-rekognition-sandbox/application"
+	"github.com/keitakn/aws-rekognition-sandbox/application/scenario/imagerecognition"
 	"github.com/keitakn/aws-rekognition-sandbox/infrastructure"
 )
 
-var scenario *application.ImageRecognitionScenario
+var scenario *imagerecognition.ImageRecognitionScenario
 
 //nolint:gochecknoinits
 func init() {
@@ -34,7 +34,7 @@ func init() {
 
 	rekognitionClient := rekognition.NewFromConfig(cfg)
 
-	scenario = &application.ImageRecognitionScenario{
+	scenario = &imagerecognition.ImageRecognitionScenario{
 		RekognitionClient: rekognitionClient,
 		S3Uploader:        uploader,
 		UniqueIdGenerator: &infrastructure.UuidGenerator{},
@@ -91,7 +91,7 @@ func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 
 	res := scenario.ImageRecognition(
 		ctx,
-		application.ImageRecognitionRequestBody{
+		imagerecognition.ImageRecognitionRequestBody{
 			Image:          reqBody.Image,
 			ImageExtension: reqBody.ImageExtension,
 		},

--- a/cmd/lambda/imagerecognition/main.go
+++ b/cmd/lambda/imagerecognition/main.go
@@ -16,9 +16,7 @@ import (
 	"github.com/keitakn/aws-rekognition-sandbox/infrastructure"
 )
 
-var uploader *manager.Uploader
-var rekognitionClient *rekognition.Client
-var imageRecognitionScenario *application.ImageRecognitionScenario
+var scenario *application.ImageRecognitionScenario
 
 //nolint:gochecknoinits
 func init() {
@@ -32,11 +30,11 @@ func init() {
 	}
 
 	s3Client := s3.NewFromConfig(cfg)
-	uploader = manager.NewUploader(s3Client)
+	uploader := manager.NewUploader(s3Client)
 
-	rekognitionClient = rekognition.NewFromConfig(cfg)
+	rekognitionClient := rekognition.NewFromConfig(cfg)
 
-	imageRecognitionScenario = &application.ImageRecognitionScenario{
+	scenario = &application.ImageRecognitionScenario{
 		RekognitionClient: rekognitionClient,
 		S3Uploader:        uploader,
 		UniqueIdGenerator: &infrastructure.UuidGenerator{},
@@ -91,7 +89,7 @@ func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 		return res, err
 	}
 
-	res := imageRecognitionScenario.ImageRecognition(
+	res := scenario.ImageRecognition(
 		ctx,
 		application.ImageRecognitionRequestBody{
 			Image:          reqBody.Image,

--- a/cmd/lambda/judgeifcatimage/main.go
+++ b/cmd/lambda/judgeifcatimage/main.go
@@ -10,10 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/keitakn/aws-rekognition-sandbox/application"
+	"github.com/keitakn/aws-rekognition-sandbox/application/scenario/judgeifcatimage"
 )
 
-var scenario *application.JudgeIfCatImageScenario
+var scenario *judgeifcatimage.JudgeIfCatImageScenario
 
 //nolint:gochecknoinits
 func init() {
@@ -30,7 +30,7 @@ func init() {
 
 	rekognitionClient := rekognition.NewFromConfig(cfg)
 
-	scenario = &application.JudgeIfCatImageScenario{
+	scenario = &judgeifcatimage.JudgeIfCatImageScenario{
 		S3Client:          s3Client,
 		RekognitionClient: rekognitionClient,
 	}
@@ -39,7 +39,7 @@ func init() {
 func Handler(ctx context.Context, event events.S3Event) error {
 	for _, record := range event.Records {
 		// recordの中にイベント発生させたS3のBucket名やKeyが入っている
-		judgeIfCatImageRequest := &application.JudgeIfCatImageRequest{
+		judgeIfCatImageRequest := &judgeifcatimage.JudgeIfCatImageRequest{
 			TargetS3BucketName:      record.S3.Bucket.Name,
 			TargetS3ObjectKey:       record.S3.Object.Key,
 			TargetS3ObjectVersionId: record.S3.Object.VersionID,
@@ -56,7 +56,7 @@ func Handler(ctx context.Context, event events.S3Event) error {
 			continue
 		}
 
-		copyCatImageRequest := &application.CopyCatImageToDestinationBucketRequest{
+		copyCatImageRequest := &judgeifcatimage.CopyCatImageToDestinationBucketRequest{
 			// TriggerBucketName, DestinationBucketNameに同じ値が設定されているが、同じバケットの異なるディレクトリを使っているから
 			// 実運用の際は別のバケットを指定したほうが良い
 			TriggerBucketName:     os.Getenv("TRIGGER_BUCKET_NAME"),


### PR DESCRIPTION
# issueURL
なし

# 内容

カバレッジを出力するようにテストと実装を同じpackageに配置するようにしました。

以下の軽微な変更も行いました。

- `make ci` でCIのチェックに必要なコマンドを全て含むように改修
- Lambdaのエントリーポイント内でグローバル変数にすべきなのはscenarioだけなので、そのように変更