### PR TITLE
goverallsを利用してカバレッジレポートを送信するように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,13 @@ jobs:
       - name: Execute test
         run: |
           docker-compose exec -T go make ci
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - name: Install goveralls
+        run: go install github.com/mattn/goveralls@latest
+      - name: Send coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goveralls -coverprofile=covprofile.out -service=github

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format:
 ci: clean build lint
 	go mod tidy && git diff -s --exit-code go.sum
 	go clean -testcache
-	go test -p 1 -v -coverprofile coverage.out -covermode atomic $$(go list ./... | grep -v /node_modules/)
+	go test -p 1 -v -covermode atomic -coverprofile=covprofile.out $$(go list ./... | grep -v /node_modules/)
 
 generate-mock:
 	mockgen -source=infrastructure/rekognition_client.go -destination mock/rekognition_client.go -package mock


### PR DESCRIPTION
# issueURL
なし

# やった事
以前の方法だと上手くいかなかったので、https://github.com/mattn/goveralls を使う形に改修。