### PR TITLE
Goのバージョンを1.17系に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
       - name: Install goveralls
         run: go install github.com/mattn/goveralls@latest
       - name: Send coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.14
 
 LABEL maintainer="https://github.com/keitakn"
 
@@ -6,7 +6,7 @@ WORKDIR /go/app
 
 COPY . .
 
-ARG GOLANGCI_LINT_VERSION=v1.39.0
+ARG GOLANGCI_LINT_VERSION=v1.42.1
 ARG GOMOCK_VERSION=v1.6.0
 
 RUN set -eux && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keitakn/aws-rekognition-sandbox
 
-go 1.16
+go 1.17
 
 require (
 	github.com/aws/aws-lambda-go v1.23.0
@@ -12,4 +12,16 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/credentials v1.1.4 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.0.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.2.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.1.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.2.1 // indirect
+	github.com/aws/smithy-go v1.3.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/aws-rekognition-sandbox/issues/20

# やった事
Goのバージョンを1.17系に変更、Dockerfile内でインストールしている `golangci-lint` も最新安定版に更新。