### PR TITLE
アプリケーション層のpackage名をusecaseに変更

### DIFF
--- a/cmd/lambda/detectfaces/main.go
+++ b/cmd/lambda/detectfaces/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"github.com/keitakn/aws-rekognition-sandbox/usecase/detectfaces"
 	"log"
 	"os"
 
@@ -10,10 +11,9 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
-	"github.com/keitakn/aws-rekognition-sandbox/application/scenario/detectfaces"
 )
 
-var scenario *detectfaces.DetectFacesScenario
+var detectFacesUseCase *detectfaces.UseCase
 
 //nolint:gochecknoinits
 func init() {
@@ -28,7 +28,7 @@ func init() {
 
 	rekognitionClient := rekognition.NewFromConfig(cfg)
 
-	scenario = &detectfaces.DetectFacesScenario{RekognitionClient: rekognitionClient}
+	detectFacesUseCase = &detectfaces.UseCase{RekognitionClient: rekognitionClient}
 }
 
 func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGatewayV2HTTPResponse {
@@ -45,7 +45,7 @@ func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGa
 }
 
 func createErrorResponse(statusCode int, message string) events.APIGatewayV2HTTPResponse {
-	resBody := &detectfaces.DetectFacesResponseErrorBody{Message: message}
+	resBody := &detectfaces.ResponseErrorBody{Message: message}
 	resBodyJson, _ := json.Marshal(resBody)
 
 	res := events.APIGatewayV2HTTPResponse{
@@ -61,7 +61,7 @@ func createErrorResponse(statusCode int, message string) events.APIGatewayV2HTTP
 }
 
 func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
-	var reqBody detectfaces.DetectFacesRequestBody
+	var reqBody detectfaces.RequestBody
 	if err := json.Unmarshal([]byte(req.Body), &reqBody); err != nil {
 		statusCode := 400
 
@@ -70,7 +70,7 @@ func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 		return res, err
 	}
 
-	scenarioRes := scenario.DetectFaces(ctx, reqBody)
+	scenarioRes := detectFacesUseCase.DetectFaces(ctx, reqBody)
 	if scenarioRes.IsError {
 		statusCode := 500
 

--- a/cmd/lambda/detectfaces/main.go
+++ b/cmd/lambda/detectfaces/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/keitakn/aws-rekognition-sandbox/usecase/detectfaces"
 	"log"
 	"os"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
+	"github.com/keitakn/aws-rekognition-sandbox/usecase/detectfaces"
 )
 
 var detectFacesUseCase *detectfaces.UseCase

--- a/cmd/lambda/imagerecognition/main.go
+++ b/cmd/lambda/imagerecognition/main.go
@@ -12,11 +12,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/keitakn/aws-rekognition-sandbox/application/scenario/imagerecognition"
 	"github.com/keitakn/aws-rekognition-sandbox/infrastructure"
+	"github.com/keitakn/aws-rekognition-sandbox/usecase/imagerecognition"
 )
 
-var scenario *imagerecognition.ImageRecognitionScenario
+var imageRecognitionUseCase *imagerecognition.UseCase
 
 //nolint:gochecknoinits
 func init() {
@@ -34,7 +34,7 @@ func init() {
 
 	rekognitionClient := rekognition.NewFromConfig(cfg)
 
-	scenario = &imagerecognition.ImageRecognitionScenario{
+	imageRecognitionUseCase = &imagerecognition.UseCase{
 		RekognitionClient: rekognitionClient,
 		S3Uploader:        uploader,
 		UniqueIdGenerator: &infrastructure.UuidGenerator{},
@@ -89,9 +89,9 @@ func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 		return res, err
 	}
 
-	res := scenario.ImageRecognition(
+	res := imageRecognitionUseCase.ImageRecognition(
 		ctx,
-		imagerecognition.ImageRecognitionRequestBody{
+		imagerecognition.RequestBody{
 			Image:          reqBody.Image,
 			ImageExtension: reqBody.ImageExtension,
 		},

--- a/usecase/detectfaces/usecase.go
+++ b/usecase/detectfaces/usecase.go
@@ -9,47 +9,47 @@ import (
 	"github.com/keitakn/aws-rekognition-sandbox/infrastructure"
 )
 
-type DetectFacesRequestBody struct {
+type RequestBody struct {
 	Image string `json:"image"`
 }
 
-type DetectFacesResponseOkBody struct {
+type ResponseOkBody struct {
 	DetectFacesOutput *rekognition.DetectFacesOutput `json:"detectFacesOutput"`
 }
 
-type DetectFacesResponseErrorBody struct {
+type ResponseErrorBody struct {
 	Message string `json:"message"`
 }
 
-type DetectFacesResponse struct {
-	OkBody    *DetectFacesResponseOkBody
+type Response struct {
+	OkBody    *ResponseOkBody
 	IsError   bool
-	ErrorBody *DetectFacesResponseErrorBody
+	ErrorBody *ResponseErrorBody
 }
 
-type DetectFacesScenario struct {
+type UseCase struct {
 	RekognitionClient infrastructure.RekognitionClient
 }
 
-func (s *DetectFacesScenario) DetectFaces(ctx context.Context, req DetectFacesRequestBody) *DetectFacesResponse {
+func (s *UseCase) DetectFaces(ctx context.Context, req RequestBody) *Response {
 	decodedImg, err := base64.StdEncoding.DecodeString(req.Image)
 	if err != nil {
-		return &DetectFacesResponse{
+		return &Response{
 			IsError:   true,
-			ErrorBody: &DetectFacesResponseErrorBody{Message: "Failed Decode Base64 Image"},
+			ErrorBody: &ResponseErrorBody{Message: "Failed Decode Base64 Image"},
 		}
 	}
 
 	detectFacesOutput, err := s.detectFaces(ctx, decodedImg)
 	if err != nil {
-		return &DetectFacesResponse{
+		return &Response{
 			IsError:   true,
-			ErrorBody: &DetectFacesResponseErrorBody{Message: "Failed detectFaces"},
+			ErrorBody: &ResponseErrorBody{Message: "Failed detectFaces"},
 		}
 	}
 
-	return &DetectFacesResponse{
-		OkBody: &DetectFacesResponseOkBody{
+	return &Response{
+		OkBody: &ResponseOkBody{
 			DetectFacesOutput: detectFacesOutput,
 		},
 		IsError: false,
@@ -57,7 +57,7 @@ func (s *DetectFacesScenario) DetectFaces(ctx context.Context, req DetectFacesRe
 }
 
 func (
-	s *DetectFacesScenario,
+	s *UseCase,
 ) detectFaces(
 	ctx context.Context,
 	decodedImg []byte,

--- a/usecase/detectfaces/usecase.go
+++ b/usecase/detectfaces/usecase.go
@@ -31,7 +31,7 @@ type UseCase struct {
 	RekognitionClient infrastructure.RekognitionClient
 }
 
-func (s *UseCase) DetectFaces(ctx context.Context, req RequestBody) *Response {
+func (u *UseCase) DetectFaces(ctx context.Context, req RequestBody) *Response {
 	decodedImg, err := base64.StdEncoding.DecodeString(req.Image)
 	if err != nil {
 		return &Response{
@@ -40,7 +40,7 @@ func (s *UseCase) DetectFaces(ctx context.Context, req RequestBody) *Response {
 		}
 	}
 
-	detectFacesOutput, err := s.detectFaces(ctx, decodedImg)
+	detectFacesOutput, err := u.detectFaces(ctx, decodedImg)
 	if err != nil {
 		return &Response{
 			IsError:   true,
@@ -57,7 +57,7 @@ func (s *UseCase) DetectFaces(ctx context.Context, req RequestBody) *Response {
 }
 
 func (
-	s *UseCase,
+	u *UseCase,
 ) detectFaces(
 	ctx context.Context,
 	decodedImg []byte,
@@ -71,7 +71,7 @@ func (
 		Image: rekognitionImage,
 	}
 
-	output, err := s.RekognitionClient.DetectFaces(ctx, input)
+	output, err := u.RekognitionClient.DetectFaces(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/usecase/detectfaces/usecase_test.go
+++ b/usecase/detectfaces/usecase_test.go
@@ -28,7 +28,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -53,18 +53,18 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(expectedDetectFacesOutput, nil)
 
-		req := &DetectFacesRequestBody{
+		req := &RequestBody{
 			Image: base64Img,
 		}
 
-		scenario := &DetectFacesScenario{
+		u := &UseCase{
 			RekognitionClient: mockClient,
 		}
 
-		res := scenario.DetectFaces(ctx, *req)
+		res := u.DetectFaces(ctx, *req)
 
-		expected := &DetectFacesResponse{
-			OkBody: &DetectFacesResponseOkBody{
+		expected := &Response{
+			OkBody: &ResponseOkBody{
 				DetectFacesOutput: expectedDetectFacesOutput,
 			},
 			IsError: false,
@@ -86,7 +86,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../../test/images/munchkin-cat.png")
+		base64Img, err := test.EncodeImageToBase64("../../test/images/munchkin-cat.png")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -110,18 +110,18 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(expectedDetectFacesOutput, nil)
 
-		req := &DetectFacesRequestBody{
+		req := &RequestBody{
 			Image: base64Img,
 		}
 
-		scenario := &DetectFacesScenario{
+		u := &UseCase{
 			RekognitionClient: mockClient,
 		}
 
-		res := scenario.DetectFaces(ctx, *req)
+		res := u.DetectFaces(ctx, *req)
 
-		expected := &DetectFacesResponse{
-			OkBody: &DetectFacesResponseOkBody{
+		expected := &Response{
+			OkBody: &ResponseOkBody{
 				DetectFacesOutput: expectedDetectFacesOutput,
 			},
 			IsError: false,
@@ -143,7 +143,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../../test/images/munchkin-cat.png")
+		base64Img, err := test.EncodeImageToBase64("../../test/images/munchkin-cat.png")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -162,18 +162,18 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(nil, expectedDetectError)
 
-		req := &DetectFacesRequestBody{
+		req := &RequestBody{
 			Image: base64Img,
 		}
 
-		scenario := &DetectFacesScenario{
+		u := &UseCase{
 			RekognitionClient: mockClient,
 		}
 
-		res := scenario.DetectFaces(ctx, *req)
+		res := u.DetectFaces(ctx, *req)
 
-		expected := &DetectFacesResponse{
-			ErrorBody: &DetectFacesResponseErrorBody{Message: "Failed detectFaces"},
+		expected := &Response{
+			ErrorBody: &ResponseErrorBody{Message: "Failed detectFaces"},
 			IsError:   true,
 		}
 

--- a/usecase/imagerecognition/usecase_test.go
+++ b/usecase/imagerecognition/usecase_test.go
@@ -33,7 +33,7 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -103,18 +103,18 @@ func TestHandler(t *testing.T) {
 		mockUniqueIdGenerator := mock.NewMockUniqueIdGenerator(ctrl)
 		mockUniqueIdGenerator.EXPECT().Generate().Return(mockUuid, nil)
 
-		scenario := ImageRecognitionScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 			S3Uploader:        mockS3Uploader,
 			UniqueIdGenerator: mockUniqueIdGenerator,
 		}
 
-		req := ImageRecognitionRequestBody{
+		req := RequestBody{
 			Image:          base64Img,
 			ImageExtension: ".jpg",
 		}
 
-		res := scenario.ImageRecognition(ctx, req)
+		res := u.ImageRecognition(ctx, req)
 
 		resFirstLabelName := *res.OkBody.Labels[0].Name
 		if resFirstLabelName != expectedFirstLabelName {
@@ -140,7 +140,7 @@ func TestHandler(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -152,19 +152,19 @@ func TestHandler(t *testing.T) {
 		mockUniqueIdGenerator := mock.NewMockUniqueIdGenerator(ctrl)
 		mockUniqueIdGenerator.EXPECT().Generate().Return("", errors.New("failed Generate UUID"))
 
-		scenario := ImageRecognitionScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 			S3Uploader:        mockS3Uploader,
 			UniqueIdGenerator: mockUniqueIdGenerator,
 		}
 
-		req := ImageRecognitionRequestBody{
+		req := RequestBody{
 			Image:          base64Img,
 			ImageExtension: ".jpg",
 		}
 
 		ctx := context.Background()
-		res := scenario.ImageRecognition(ctx, req)
+		res := u.ImageRecognition(ctx, req)
 
 		if !res.IsError {
 			t.Error("\nActually: ", res.IsError, "\nExpected: ", true)
@@ -182,7 +182,7 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -212,18 +212,18 @@ func TestHandler(t *testing.T) {
 		mockUniqueIdGenerator := mock.NewMockUniqueIdGenerator(ctrl)
 		mockUniqueIdGenerator.EXPECT().Generate().Return(mockUuid, nil)
 
-		scenario := ImageRecognitionScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 			S3Uploader:        mockS3Uploader,
 			UniqueIdGenerator: mockUniqueIdGenerator,
 		}
 
-		req := ImageRecognitionRequestBody{
+		req := RequestBody{
 			Image:          base64Img,
 			ImageExtension: ".jpg",
 		}
 
-		res := scenario.ImageRecognition(ctx, req)
+		res := u.ImageRecognition(ctx, req)
 
 		if !res.IsError {
 			t.Error("\nActually: ", res.IsError, "\nExpected: ", true)
@@ -241,7 +241,7 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
 
-		base64Img, err := test.EncodeImageToBase64("../../../test/images/moko-cat.jpg")
+		base64Img, err := test.EncodeImageToBase64("../../test/images/moko-cat.jpg")
 		if err != nil {
 			t.Fatal("Error failed to encodeImageToBase64", err)
 		}
@@ -293,18 +293,18 @@ func TestHandler(t *testing.T) {
 		mockUniqueIdGenerator := mock.NewMockUniqueIdGenerator(ctrl)
 		mockUniqueIdGenerator.EXPECT().Generate().Return(mockUuid, nil)
 
-		scenario := ImageRecognitionScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 			S3Uploader:        mockS3Uploader,
 			UniqueIdGenerator: mockUniqueIdGenerator,
 		}
 
-		req := ImageRecognitionRequestBody{
+		req := RequestBody{
 			Image:          base64Img,
 			ImageExtension: ".jpg",
 		}
 
-		res := scenario.ImageRecognition(ctx, req)
+		res := u.ImageRecognition(ctx, req)
 
 		if !res.IsError {
 			t.Error("\nActually: ", res.IsError, "\nExpected: ", true)

--- a/usecase/judgeifcatimage/usecase_test.go
+++ b/usecase/judgeifcatimage/usecase_test.go
@@ -76,17 +76,17 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
 
-		scenario := JudgeIfCatImageScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &JudgeIfCatImageRequest{
+		req := &Request{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
 		}
 
-		res, err := scenario.JudgeIfCatImage(ctx, req)
+		res, err := u.JudgeIfCatImage(ctx, req)
 		if err != nil {
 			t.Fatal("Failed JudgeIfCatImage", err)
 		}
@@ -144,17 +144,17 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
 
-		scenario := JudgeIfCatImageScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &JudgeIfCatImageRequest{
+		req := &Request{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
 		}
 
-		res, err := scenario.JudgeIfCatImage(ctx, req)
+		res, err := u.JudgeIfCatImage(ctx, req)
 		if err != nil {
 			t.Fatal("Failed JudgeIfCatImage", err)
 		}
@@ -211,17 +211,17 @@ func TestHandler(t *testing.T) {
 
 		mockRekognitionClient.EXPECT().DetectLabels(ctx, detectLabelsInput).Return(detectLabelsOutput, nil)
 
-		scenario := JudgeIfCatImageScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &JudgeIfCatImageRequest{
+		req := &Request{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
 		}
 
-		res, err := scenario.JudgeIfCatImage(ctx, req)
+		res, err := u.JudgeIfCatImage(ctx, req)
 		if err != nil {
 			t.Fatal("Failed JudgeIfCatImage", err)
 		}
@@ -242,11 +242,11 @@ func TestHandler(t *testing.T) {
 		mockRekognitionClient := mock.NewMockRekognitionClient(ctrl)
 		expectedTargetS3ObjectKey := "tmp/sample-cat-image.gif"
 
-		scenario := JudgeIfCatImageScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &JudgeIfCatImageRequest{
+		req := &Request{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
@@ -255,7 +255,7 @@ func TestHandler(t *testing.T) {
 		ctx := context.Background()
 
 		expected := "Not Allowed ImageExtension"
-		_, err := scenario.JudgeIfCatImage(ctx, req)
+		_, err := u.JudgeIfCatImage(ctx, req)
 		if err.Error() != expected {
 			t.Error("\nActually: ", err.Error(), "\nExpected: ", expected)
 		}
@@ -299,18 +299,18 @@ func TestHandler(t *testing.T) {
 			errors.New("failed rekognitionClient detectLabels"),
 		)
 
-		scenario := JudgeIfCatImageScenario{
+		u := UseCase{
 			RekognitionClient: mockRekognitionClient,
 		}
 
-		req := &JudgeIfCatImageRequest{
+		req := &Request{
 			TargetS3BucketName:      expectedTriggerBucketName,
 			TargetS3ObjectKey:       expectedTargetS3ObjectKey,
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
 		}
 
 		expected := "failed detectLabels"
-		_, err := scenario.JudgeIfCatImage(ctx, req)
+		_, err := u.JudgeIfCatImage(ctx, req)
 		if err.Error() != expected {
 			t.Error("\nActually: ", err.Error(), "\nExpected: ", expected)
 		}


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/aws-rekognition-sandbox/issues/25

# やった事
アプリケーション層のpackage名をusecaseに変更。

Goでレイヤードアーキテクチャをやる場合はusecaseという名称を使っているケースが多かったのでそれに合わせた。