### PR TITLE
UseCaseのメソッドで異常が発生した際はエラーを返すように変更

### DIFF
--- a/cmd/lambda/imagerecognition/main.go
+++ b/cmd/lambda/imagerecognition/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/keitakn/aws-rekognition-sandbox/infrastructure"
 	"github.com/keitakn/aws-rekognition-sandbox/usecase/imagerecognition"
+	"github.com/pkg/errors"
 )
 
 var imageRecognitionUseCase *imagerecognition.UseCase
@@ -89,7 +90,7 @@ func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 		return res, err
 	}
 
-	res := imageRecognitionUseCase.ImageRecognition(
+	res, err := imageRecognitionUseCase.ImageRecognition(
 		ctx,
 		imagerecognition.RequestBody{
 			Image:          reqBody.Image,
@@ -97,14 +98,14 @@ func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 		},
 	)
 
-	if res.IsError {
+	if err != nil {
 		statusCode := 500
-		resp := createErrorResponse(statusCode, res.ErrorBody.Message)
+		resp := createErrorResponse(statusCode, errors.Cause(err).Error())
 
 		return resp, nil
 	}
 
-	resBodyJson, _ := json.Marshal(res.OkBody)
+	resBodyJson, _ := json.Marshal(res)
 
 	statusCode := 200
 	resp := createApiGatewayV2Response(statusCode, resBodyJson)

--- a/infrastructure/unique_id_generator.go
+++ b/infrastructure/unique_id_generator.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 )
 
 type UniqueIdGenerator interface {
@@ -13,7 +14,7 @@ type UuidGenerator struct{}
 func (g *UuidGenerator) Generate() (string, error) {
 	uid, err := uuid.NewRandom()
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "failed to uuid.NewRandom")
 	}
 
 	return uid.String(), nil

--- a/usecase/catimage/usecase_test.go
+++ b/usecase/catimage/usecase_test.go
@@ -254,10 +254,10 @@ func TestHandler(t *testing.T) {
 
 		ctx := context.Background()
 
-		expected := "Not Allowed ImageExtension"
 		_, err := u.IsAcceptableCatImage(ctx, req)
-		if err.Error() != expected {
-			t.Error("\nActually: ", err.Error(), "\nExpected: ", expected)
+		expected := ErrNotAllowedImageExtension
+		if !errors.Is(err, expected) {
+			t.Error("\nActually: ", err, "\nExpected: ", expected)
 		}
 	})
 
@@ -309,10 +309,10 @@ func TestHandler(t *testing.T) {
 			TargetS3ObjectVersionId: expectedTargetS3ObjectVersionId,
 		}
 
-		expected := "failed detectLabels"
 		_, err := u.IsAcceptableCatImage(ctx, req)
-		if err.Error() != expected {
-			t.Error("\nActually: ", err.Error(), "\nExpected: ", expected)
+		expected := ErrUnexpected
+		if !errors.Is(err, expected) {
+			t.Error("\nActually: ", err, "\nExpected: ", expected)
 		}
 	})
 }

--- a/usecase/detectfaces/usecase_test.go
+++ b/usecase/detectfaces/usecase_test.go
@@ -53,7 +53,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(expectedDetectFacesOutput, nil)
 
-		req := &RequestBody{
+		req := &Request{
 			Image: base64Img,
 		}
 
@@ -61,16 +61,16 @@ func TestHandler(t *testing.T) {
 			RekognitionClient: mockClient,
 		}
 
-		res := u.DetectFaces(ctx, *req)
-
-		expected := &Response{
-			OkBody: &ResponseOkBody{
-				DetectFacesOutput: expectedDetectFacesOutput,
-			},
-			IsError: false,
+		res, err := u.DetectFaces(ctx, *req)
+		if err != nil {
+			t.Fatal("Error failed to DetectFaces", err)
 		}
 
-		resConfidence := *res.OkBody.DetectFacesOutput.FaceDetails[0].Confidence
+		expected := &Response{
+			DetectFacesOutput: expectedDetectFacesOutput,
+		}
+
+		resConfidence := *res.DetectFacesOutput.FaceDetails[0].Confidence
 		if resConfidence != confidenceExpected {
 			t.Error("\nActually: ", resConfidence, "\nExpected: ", confidenceExpected)
 		}
@@ -110,7 +110,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(expectedDetectFacesOutput, nil)
 
-		req := &RequestBody{
+		req := &Request{
 			Image: base64Img,
 		}
 
@@ -118,16 +118,16 @@ func TestHandler(t *testing.T) {
 			RekognitionClient: mockClient,
 		}
 
-		res := u.DetectFaces(ctx, *req)
-
-		expected := &Response{
-			OkBody: &ResponseOkBody{
-				DetectFacesOutput: expectedDetectFacesOutput,
-			},
-			IsError: false,
+		res, err := u.DetectFaces(ctx, *req)
+		if err != nil {
+			t.Fatal("Error failed to DetectFaces", err)
 		}
 
-		resFaceDetails := res.OkBody.DetectFacesOutput.FaceDetails
+		expected := &Response{
+			DetectFacesOutput: expectedDetectFacesOutput,
+		}
+
+		resFaceDetails := res.DetectFacesOutput.FaceDetails
 		if len(resFaceDetails) != 0 {
 			t.Error("\nActually: ", resFaceDetails)
 		}
@@ -162,7 +162,7 @@ func TestHandler(t *testing.T) {
 
 		mockClient.EXPECT().DetectFaces(ctx, params).Return(nil, expectedDetectError)
 
-		req := &RequestBody{
+		req := &Request{
 			Image: base64Img,
 		}
 
@@ -170,19 +170,10 @@ func TestHandler(t *testing.T) {
 			RekognitionClient: mockClient,
 		}
 
-		res := u.DetectFaces(ctx, *req)
-
-		expected := &Response{
-			ErrorBody: &ResponseErrorBody{Message: "Failed detectFaces"},
-			IsError:   true,
-		}
-
-		if res.ErrorBody.Message != expected.ErrorBody.Message {
-			t.Error("\nActually: ", res.ErrorBody.Message, "\nExpected: ", expected.ErrorBody.Message)
-		}
-
-		if reflect.DeepEqual(res, expected) == false {
-			t.Error("\nActually: ", res, "\nExpected: ", expected)
+		_, err = u.DetectFaces(ctx, *req)
+		expected := ErrUnexpected
+		if !errors.Is(err, expected) {
+			t.Error("\nActually: ", err, "\nExpected: ", expected)
 		}
 	})
 }

--- a/usecase/imagerecognition/usecase_test.go
+++ b/usecase/imagerecognition/usecase_test.go
@@ -114,25 +114,21 @@ func TestHandler(t *testing.T) {
 			ImageExtension: ".jpg",
 		}
 
-		res := u.ImageRecognition(ctx, req)
+		res, _ := u.ImageRecognition(ctx, req)
 
-		resFirstLabelName := *res.OkBody.Labels[0].Name
+		resFirstLabelName := *res.Labels[0].Name
 		if resFirstLabelName != expectedFirstLabelName {
 			t.Error("\nActually: ", resFirstLabelName, "\nExpected: ", expectedFirstLabelName)
 		}
 
-		resSecondLabelName := *res.OkBody.Labels[1].Name
+		resSecondLabelName := *res.Labels[1].Name
 		if resSecondLabelName != expectedSecondLabelName {
 			t.Error("\nActually: ", resSecondLabelName, "\nExpected: ", expectedSecondLabelName)
 		}
 
-		resFirstParentsName := *res.OkBody.Labels[1].Parents[0].Name
+		resFirstParentsName := *res.Labels[1].Parents[0].Name
 		if resFirstParentsName != expectedFirstParentsName {
 			t.Error("\nActually: ", resFirstParentsName, "\nExpected: ", expectedFirstParentsName)
-		}
-
-		if res.IsError {
-			t.Error("\nActually: ", res.IsError, "\nExpected: ", false)
 		}
 	})
 
@@ -164,15 +160,11 @@ func TestHandler(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		res := u.ImageRecognition(ctx, req)
 
-		if !res.IsError {
-			t.Error("\nActually: ", res.IsError, "\nExpected: ", true)
-		}
-
-		expectedErrorMessage := "Failed Generate UniqueId"
-		if res.ErrorBody.Message != expectedErrorMessage {
-			t.Error("\nActually: ", res.ErrorBody.Message, "\nExpected: ", expectedErrorMessage)
+		_, err = u.ImageRecognition(ctx, req)
+		expected := ErrGenerateUniqueId
+		if !errors.Is(err, expected) {
+			t.Error("\nActually: ", err, "\nExpected: ", expected)
 		}
 	})
 
@@ -223,15 +215,10 @@ func TestHandler(t *testing.T) {
 			ImageExtension: ".jpg",
 		}
 
-		res := u.ImageRecognition(ctx, req)
-
-		if !res.IsError {
-			t.Error("\nActually: ", res.IsError, "\nExpected: ", true)
-		}
-
-		expectedErrorMessage := "Failed Upload To S3"
-		if res.ErrorBody.Message != expectedErrorMessage {
-			t.Error("\nActually: ", res.ErrorBody.Message, "\nExpected: ", expectedErrorMessage)
+		_, err = u.ImageRecognition(ctx, req)
+		expected := ErrUploadToS3
+		if !errors.Is(err, expected) {
+			t.Error("\nActually: ", err, "\nExpected: ", expected)
 		}
 	})
 
@@ -304,15 +291,10 @@ func TestHandler(t *testing.T) {
 			ImageExtension: ".jpg",
 		}
 
-		res := u.ImageRecognition(ctx, req)
-
-		if !res.IsError {
-			t.Error("\nActually: ", res.IsError, "\nExpected: ", true)
-		}
-
-		expectedErrorMessage := "Failed recognition"
-		if res.ErrorBody.Message != expectedErrorMessage {
-			t.Error("\nActually: ", res.ErrorBody.Message, "\nExpected: ", expectedErrorMessage)
+		_, err = u.ImageRecognition(ctx, req)
+		expected := ErrRekognition
+		if !errors.Is(err, expected) {
+			t.Error("\nActually: ", err, "\nExpected: ", expected)
 		}
 	})
 }


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/aws-rekognition-sandbox/issues/29

# やった事
Goの慣例に合わせてエラー発生時はエラーを返すように変更。

ロギングの際にスタックトレースが欲しいので `errors.Wrap` を使うように変更。